### PR TITLE
add action api to extensionizer for mv3 support

### DIFF
--- a/extension-instance.js
+++ b/extension-instance.js
@@ -1,6 +1,7 @@
 const apis = [
   'alarms',
   'bookmarks',
+  'action',
   'browserAction',
   'commands',
   'contextMenus',
@@ -76,6 +77,13 @@ function Extension () {
     try {
       if (browser && browser.browserAction) {
         this.browserAction = browser.browserAction
+      }
+    } catch (e) {
+    }
+
+    try {
+      if (browser && browser.action) {
+        this.action = browser.action
       }
     } catch (e) {
     }


### PR DESCRIPTION
Required for MV3 migration: https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#action-api-unification

Currently attempting to [POC the deprecation of this package](https://github.com/MetaMask/extensionizer/issues/21) in favor of https://github.com/mozilla/webextension-polyfill but until we resolve the build issues to make use of that package I'm making the piecemeal changes we would require to move forward with this package.